### PR TITLE
✨Feat: 랜딩 페이지 기초 ui 구성

### DIFF
--- a/src/pages/landing/LandingPage.jsx
+++ b/src/pages/landing/LandingPage.jsx
@@ -1,9 +1,19 @@
-import React from 'react';
+import CustomButton from '@/components/customButton';
+import { Link } from 'react-router-dom';
+import * as S from './landingPage.styles';
 
 const LandingPage = () => {
+  const handleClearStorage = () => {
+    localStorage.clear();
+  };
+
   return (
-    <div>
-      <h1>랜딩페이지</h1>
+    <div css={S.landingWrapper}>
+      <Link to="/list" onClick={handleClearStorage}>
+        <CustomButton type="button" variant="landing">
+          지금 시작하기
+        </CustomButton>
+      </Link>
     </div>
   );
 };

--- a/src/pages/landing/index.js
+++ b/src/pages/landing/index.js
@@ -1,0 +1,1 @@
+export { default as LandingPage } from './LandingPage';

--- a/src/pages/landing/landingPage.styles.js
+++ b/src/pages/landing/landingPage.styles.js
@@ -1,0 +1,8 @@
+import { css } from '@emotion/react';
+
+export const landingWrapper = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+`;

--- a/src/routes/router.jsx
+++ b/src/routes/router.jsx
@@ -18,7 +18,7 @@ const router = createBrowserRouter([
         index: true,
 
         lazy: async () => {
-          const { default: LandingPage } = await import('@/pages/landing/LandingPage');
+          const { LandingPage } = await import('@/pages/landing');
           return { Component: LandingPage };
         },
       },


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #162 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
- 랜딩페이지 '지금 시작하기' 버튼 구현

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->
- 랜딩페이지 폴더 구조도 변경한 뒤, 라우터에서 import 하는 방식을 수정했습니다.
- `/list` 로 가는 '지금 시작하기' 버튼에 localStorage를 초기화 하도록 구현했습니다.
- 우선 랜딩페이지를 디자인 하기 전 버튼 기능만 동작하도록 구현했습니다.

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [x] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [x] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

| 구현 전   | 구현 후   |
| --------- | --------- |
| UI 이미지 | ![image](https://github.com/user-attachments/assets/ede03bd3-6f00-4831-b627-4d1d932d7a56) |

