### PR TITLE
🐛Fix: 드래그 했을 때 모달 꺼지는 문제 수정

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -15,7 +15,11 @@ function Root() {
     <>
       {isLoading && <PendingUI />}
       {!isLanding && <Header />}
-      <main style={{ paddingTop: !isLanding ? `${LAYOUT.HEADER_HEIGHT}px` : 0 }}>
+      <main
+        style={{
+          paddingTop: !isLanding ? `${LAYOUT.HEADER_HEIGHT}px` : 0,
+        }}
+      >
         <Outlet />
       </main>
       {!isLanding && <Footer />}

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -1,4 +1,5 @@
 import exitImg from '@/assets/icons/exit-icon.png';
+import { useEffect, useState } from 'react';
 import * as S from './modal.styles';
 
 /**
@@ -20,16 +21,36 @@ import * as S from './modal.styles';
 function Modal({ isOpen, onClose, children }) {
   if (!isOpen) return null;
 
-  const handleOverlayClick = (e) => {
-    if (e.target === e.currentTarget) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleMouseDown = () => {
+    setIsDragging(false);
+  };
+
+  const handleMouseMove = () => {
+    setIsDragging(true);
+  };
+
+  const handleMouseUp = (e) => {
+    if (!isDragging && e.target === e.currentTarget) {
       onClose();
     }
+    setIsDragging(false);
   };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional polling without deps
+  useEffect(() => {
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+    };
+  }, []);
 
   return (
     <div
       css={S.overlay}
-      onClick={handleOverlayClick}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
       role="presentation"
     >


### PR DESCRIPTION
## 🧩 관련 이슈 번호

#229  

## ✨ 요약

모달 밖 화면 부분을 클릭했을때도 x눌렀을 때처럼 모달이 꺼지도록 구현했었는데
드래그했을때도 모달이 꺼지는 문제가 발견되어 수정했습니다. 

## 📌 주요 변경 사항

Modal.jsx에 해당 로직을 추가했습니다. 


## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [x] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [x] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 모달 창에서 드래그 동작과 클릭을 구분하여, 드래그 시에는 모달이 닫히지 않도록 개선되었습니다.

- **스타일**
  - 일부 스타일 속성의 코드 포맷이 가독성을 높이도록 정렬되었습니다. (기능 변화 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->