### PR TITLE
🐛Fix: PendingUI화면 전환 문제 해결 및 데모 전 리팩토링

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { AlertManager } from './components/alertManager';
-import { SplashScreen } from './components/loadingStatus/splashScreen';
+import { SplashScreen } from './components/loadingStatus';
+
 export default function App({ router }) {
   const [showSplashScreen, setShowSplashScreen] = useState(true);
 

--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -1,8 +1,8 @@
+import { Outlet, useLocation, useNavigation } from 'react-router-dom';
 import { Header } from '@/components/header';
 import { LAYOUT } from '@/constants/layout';
-import { Outlet, useLocation, useNavigation } from 'react-router-dom';
-import { Footer } from './components/footer';
-import { PendingUI } from './components/loadingStatus/pendingUI';
+import { Footer } from '@/components/footer';
+import { PendingUI } from './components/loadingStatus';
 
 function Root() {
   const navigation = useNavigation();
@@ -13,16 +13,21 @@ function Root() {
 
   return (
     <>
-      {isLoading && <PendingUI />}
-      {!isLanding && <Header />}
-      <main
-        style={{
-          paddingTop: !isLanding ? `${LAYOUT.HEADER_HEIGHT}px` : 0,
-        }}
-      >
-        <Outlet />
-      </main>
-      {!isLanding && <Footer />}
+      {isLoading ? (
+        <PendingUI />
+      ) : (
+        <>
+          {!isLanding && <Header />}
+          <main
+            style={{
+              paddingTop: !isLanding ? `${LAYOUT.HEADER_HEIGHT}px` : 0,
+            }}
+          >
+            <Outlet />
+          </main>
+          {!isLanding && <Footer />}
+        </>
+      )}
     </>
   );
 }

--- a/src/components/alert/Alert.jsx
+++ b/src/components/alert/Alert.jsx
@@ -1,6 +1,6 @@
+import React from 'react';
 import successIcon from '@/assets/icons/success-icon.png';
 import warningIcon from '@/assets/icons/warning-icon.png';
-import React from 'react';
 import * as S from './alert.styles';
 
 const Alert = ({ content = 'toast content', type = 'warning', customStyle }) => {

--- a/src/components/alert/alert.styles.js
+++ b/src/components/alert/alert.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css, keyframes } from '@emotion/react';
+import media from '@/styles/responsive';
 
 const bounceIn = keyframes`
   0% {

--- a/src/components/alertManager/AlertManager.jsx
+++ b/src/components/alertManager/AlertManager.jsx
@@ -1,6 +1,7 @@
-import { Alert } from '@/components/alert';
-import { registerAlertTrigger } from '@/utils/alert/alertController';
 import { useEffect, useRef, useState } from 'react';
+import { Alert } from '@/components/alert';
+import { registerAlertTrigger } from '@/utils/alert';
+
 const AlertManager = () => {
   const [visible, setVisible] = useState(false);
   const [content, setContent] = useState('');

--- a/src/components/avatar/avatar.styles.js
+++ b/src/components/avatar/avatar.styles.js
@@ -1,5 +1,5 @@
-import checkIcon from '@/assets/icons/check-icon.png';
 import { css } from '@emotion/react';
+import checkIcon from '@/assets/icons/check-icon.png';
 
 export const imageWrapper = (imgSize) => css`
   position: relative;

--- a/src/components/button/arrowButton/arrowButton.styles.js
+++ b/src/components/button/arrowButton/arrowButton.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const arrowIcon = css`
   height: 1.4rem;

--- a/src/components/button/avatarButton/AvatarButton.jsx
+++ b/src/components/button/avatarButton/AvatarButton.jsx
@@ -1,6 +1,6 @@
-import exitIcon from '@/assets/icons/exit-icon-black.png';
-import { Avatar } from '@/components/avatar';
 import React from 'react';
+import { Avatar } from '@/components/avatar';
+import exitIcon from '@/assets/icons/exit-icon-black.png';
 import * as S from './avatarButton.styles';
 
 const AvatarButton = ({ imgUrl, boxSize, removeIdol }) => {

--- a/src/components/button/avatarButton/avatarButton.styles.js
+++ b/src/components/button/avatarButton/avatarButton.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const avatarWrapper = css`
   display: flex;

--- a/src/components/button/customButton/customButton.styles.js
+++ b/src/components/button/customButton/customButton.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css } from '@emotion/react';
+import media from '@/styles/responsive';
 
 const getButtonStyle = (size, isRound) => css`
   display:inline-flex;

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -1,7 +1,7 @@
-import creditImg from '@/assets/images/credit.png';
-import { CustomButton } from '@/components/button';
-import { addCommas, getDaysRemaining, getDonationPercentage } from '@/utils/format';
 import { useEffect, useState } from 'react';
+import { CustomButton } from '@/components/button';
+import creditImg from '@/assets/images/credit.png';
+import { addCommas, getDaysRemaining, getDonationPercentage } from '@/utils/format';
 import * as S from './card.styles';
 
 const Card = ({ data, setModalType, setSelectedIndex, index }) => {

--- a/src/components/card/card.styles.js
+++ b/src/components/card/card.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css, keyframes } from '@emotion/react';
+import media from '@/styles/responsive';
 
 const marquee = keyframes`
   0%   { transform: translateX(30%); }

--- a/src/components/carousel/Carousel.jsx
+++ b/src/components/carousel/Carousel.jsx
@@ -1,7 +1,7 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowButton } from '@/components/button';
 import { Card } from '@/components/card';
 import { getItemMetrics } from '@/utils/carousel';
-import { useCallback, useEffect, useRef, useState } from 'react';
 import * as S from './carousel.styles';
 
 const Carousel = ({ data, setModalType, setSelectedIndex }) => {

--- a/src/components/carousel/carousel.styles.js
+++ b/src/components/carousel/carousel.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const wrapper = css`
   width: 100%;

--- a/src/components/charge/charge.styles.js
+++ b/src/components/charge/charge.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css, keyframes } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const voteButtonFlow = keyframes`
   0% {

--- a/src/components/chart/Chart.jsx
+++ b/src/components/chart/Chart.jsx
@@ -1,12 +1,11 @@
-import { fetchCharts } from '@/api';
-import chartImg from '@/assets/images/chart.png';
-import { CustomButton } from '@/components/button';
-import { LoadingSpinner } from '@/components/loadingStatus/loadingSpinner';
 import { useEffect, useState } from 'react';
-import LoadMoreButton from './LoadMoreButton';
-import * as S from './chart.styles';
+import { CustomButton } from '@/components/button';
+import { LoadingSpinner } from '@/components/loadingStatus';
+import chartImg from '@/assets/images/chart.png';
 import { fetchData } from './fetchData';
 import { useScreenSize } from './useScreenSize';
+import LoadMoreButton from './LoadMoreButton';
+import * as S from './chart.styles';
 
 const Chart = ({ setModalType, selectedTab, setSelectedTab, updateCredit }) => {
   const [chartData, setChartData] = useState([]);

--- a/src/components/chart/chart.styles.js
+++ b/src/components/chart/chart.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css, keyframes } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const flexCenter = css`
   display: flex;

--- a/src/components/footer/footer.styles.js
+++ b/src/components/footer/footer.styles.js
@@ -1,6 +1,6 @@
+import { css } from '@emotion/react';
 import { LAYOUT } from '@/constants/layout';
 import media from '@/styles/responsive';
-import { css } from '@emotion/react';
 
 export const footerWrapper = css`
   display: flex;

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,7 +1,7 @@
+import { Link } from 'react-router-dom';
 import textLogoImg from '@/assets/images/logo-text-temp.png';
 import logoImg from '@/assets/images/logo.png';
 import profileImg from '@/assets/images/stupid.png';
-import { Link } from 'react-router-dom';
 import * as S from './header.styles';
 
 const Header = () => {

--- a/src/components/header/header.styles.js
+++ b/src/components/header/header.styles.js
@@ -1,6 +1,6 @@
+import { css } from '@emotion/react';
 import { LAYOUT } from '@/constants/layout';
 import media from '@/styles/responsive';
-import { css } from '@emotion/react';
 
 export const headerWrapper = css`
   display: flex;

--- a/src/components/loadingStatus/index.js
+++ b/src/components/loadingStatus/index.js
@@ -1,0 +1,3 @@
+export { default as LoadingSpinner } from './loadingSpinner';
+export { default as PendingUI } from './pendingUI';
+export { default as SplashScreen } from './splashScreen';

--- a/src/components/loadingStatus/loadingSpinner/index.js
+++ b/src/components/loadingStatus/loadingSpinner/index.js
@@ -1,1 +1,1 @@
-export { default as LoadingSpinner } from './LoadingSpinner';
+export { default } from './LoadingSpinner';

--- a/src/components/loadingStatus/pendingUI/PendingUI.jsx
+++ b/src/components/loadingStatus/pendingUI/PendingUI.jsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/react';
 import { useNavigation } from 'react-router-dom';
+import { css } from '@emotion/react';
 import * as S from './pendingUI.styles';
 
 const stars = [

--- a/src/components/loadingStatus/pendingUI/index.js
+++ b/src/components/loadingStatus/pendingUI/index.js
@@ -1,1 +1,1 @@
-export { default as PendingUI } from './PendingUI';
+export { default } from './PendingUI';

--- a/src/components/loadingStatus/pendingUI/pendingUI.styles.js
+++ b/src/components/loadingStatus/pendingUI/pendingUI.styles.js
@@ -1,5 +1,5 @@
-import starImg from '@/assets/images/star.png';
 import { css, keyframes } from '@emotion/react';
+import starImg from '@/assets/images/star.png';
 
 const rotate = keyframes`
   0% {

--- a/src/components/loadingStatus/splashScreen/index.js
+++ b/src/components/loadingStatus/splashScreen/index.js
@@ -1,1 +1,1 @@
-export { default as SplashScreen } from './SplashScreen';
+export { default } from './SplashScreen';

--- a/src/components/modals/commonModal/Modal.jsx
+++ b/src/components/modals/commonModal/Modal.jsx
@@ -1,5 +1,5 @@
-import exitImg from '@/assets/icons/exit-icon.png';
 import { useEffect, useState } from 'react';
+import exitImg from '@/assets/icons/exit-icon.png';
 import * as S from './modal.styles';
 
 /**

--- a/src/components/modals/creditChargeModal/CreditChargeModal.jsx
+++ b/src/components/modals/creditChargeModal/CreditChargeModal.jsx
@@ -1,9 +1,9 @@
+import { useState } from 'react';
+import { CustomButton, RadioButton } from '@/components/button';
+import { Prices } from '@/constants/creditPrice';
 import starTwoImg from '@/assets/images/2-star.png';
 import starThreeImg from '@/assets/images/3-star.png';
 import starImg from '@/assets/images/star.png';
-import { CustomButton, RadioButton } from '@/components/button';
-import { Prices } from '@/constants/creditPrice';
-import { useState } from 'react';
 import * as S from './creditChargeModal.styles';
 
 const imageMap = {

--- a/src/components/modals/creditChargeModal/creditChargeModal.styles.js
+++ b/src/components/modals/creditChargeModal/creditChargeModal.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css, keyframes } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const voteButtonFlow = keyframes`
   0% {

--- a/src/components/modals/creditLackModal/CreditLackModal.jsx
+++ b/src/components/modals/creditLackModal/CreditLackModal.jsx
@@ -1,5 +1,5 @@
-import creditImg from '@/assets/images/credit.png';
 import { CustomButton } from '@/components/button';
+import creditImg from '@/assets/images/logo-star.png';
 import * as S from './creditLackModal.styles';
 
 const CreditLackModal = ({ setModalType }) => {

--- a/src/components/modals/creditLackModal/creditLackModal.styles.js
+++ b/src/components/modals/creditLackModal/creditLackModal.styles.js
@@ -8,10 +8,11 @@ export const modalContent = css`
   width: 32.7rem;
   height: auto;
   margin: 0 auto;
-  padding: 2.4rem 1.6rem; /* 다른 모달들과 동일한 패딩 값 */
+  padding: 2.4rem 1.6rem; 
+  border-radius: 8px; 
   text-align: center;
   color: var(--white-full);
-  background-color: var(--black); 
+  background-color: var(--black);
 `;
 
 export const contentWrapper = css`

--- a/src/components/modals/donationModal/DonationModal.jsx
+++ b/src/components/modals/donationModal/DonationModal.jsx
@@ -1,10 +1,10 @@
-import creditImg from '@/assets/images/credit.png';
-import { Alert } from '@/components/alert';
-import { CustomButton } from '@/components/button';
-import { ENDPOINTS } from '@/constants/api';
-import { requestPut } from '@/utils/api';
 import { useRef, useState } from 'react';
 import { useRevalidator } from 'react-router-dom';
+import { CustomButton } from '@/components/button';
+import { Alert } from '@/components/alert';
+import { ENDPOINTS } from '@/constants/api';
+import { requestPut } from '@/utils/api';
+import creditImg from '@/assets/images/credit.png';
 import * as S from './donationModal.styles';
 
 const DonationModal = ({ data, credit, updateCredit, onClose }) => {

--- a/src/components/modals/voteModal/VoteModal.jsx
+++ b/src/components/modals/voteModal/VoteModal.jsx
@@ -1,19 +1,18 @@
-import { fetchCharts } from '@/api';
-import { Alert } from '@/components/alert';
+import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/avatar';
 import { CustomButton, RadioButton } from '@/components/button';
+import { fetchCharts } from '@/api';
 import { ENDPOINTS } from '@/constants/api';
-import { showAlert } from '@/utils/alert/alertController';
-import { requestGet, requestPost } from '@/utils/api';
+import { showAlert } from '@/utils/alert';
+import { requestPost } from '@/utils/api';
 import { addCommas } from '@/utils/format';
-import { useEffect, useState } from 'react';
 import * as S from './voteModal.styles';
 const VoteModal = ({ gender, updateCredit, setModalType }) => {
   const [idols, setIdols] = useState([]);
   const [checkedItem, setCheckedItem] = useState();
 
   const loadData = async (gender) => {
-    // const chartUrl = `${ENDPOINTS.GET_CHART}?gender=${gender}&pageSize=30&`;
+    // const chartUrl = `${ENDPOINTS.GET_CHART}${gender}?gender=${gender}&pageSize=10`;
     // const response = await requestGet(chartUrl);
     const response = await fetchCharts({ gender, limit: 30 });
     return response;

--- a/src/components/modals/voteModal/voteModal.styles.js
+++ b/src/components/modals/voteModal/voteModal.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const ModalWrapper = css`
   display: flex;

--- a/src/errorBoundary/apiErrorBoundary/ApiErrorBoundary.jsx
+++ b/src/errorBoundary/apiErrorBoundary/ApiErrorBoundary.jsx
@@ -1,8 +1,8 @@
+import { useRouteError } from 'react-router-dom';
 import { CustomButton } from '@/components/button';
 import { UI_ERRORS } from '@/constants/errors';
 import { STATUS_CODES } from '@/constants/statusCodes';
 import * as S from '@/errorBoundary/styles';
-import { useRouteError } from 'react-router-dom';
 
 /**
  * ApiErrorBoundary

--- a/src/errorBoundary/globalErrorBoundary/GlobalErrorBoundary.jsx
+++ b/src/errorBoundary/globalErrorBoundary/GlobalErrorBoundary.jsx
@@ -1,5 +1,5 @@
-import { ServerErrorPage } from '@/pages/error';
 import { useRouteError } from 'react-router-dom';
+import { ServerErrorPage } from '@/pages/error';
 
 /** 전역의 최종 fallback. 라우터에서 처리하지 못한 모든 라우터 에러를 최종 처리하는 역할 */
 const GlobalErrorBoundary = () => {

--- a/src/errorBoundary/renderErrorBoundary/RenderErrorBoundary.jsx
+++ b/src/errorBoundary/renderErrorBoundary/RenderErrorBoundary.jsx
@@ -1,7 +1,7 @@
+import { Component } from 'react';
 import { CustomButton } from '@/components/button';
 import { UI_ERRORS } from '@/constants/errors';
 import * as S from '@/errorBoundary/styles';
-import { Component } from 'react';
 
 /**
  * RenderErrorBoundary

--- a/src/errorBoundary/styles/errorBoundary.styles.js
+++ b/src/errorBoundary/styles/errorBoundary.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const wrapper = css`
   max-width: 480px;

--- a/src/pages/error/notFound/NotFoundPage.jsx
+++ b/src/pages/error/notFound/NotFoundPage.jsx
@@ -1,9 +1,9 @@
-import logoImg from '@/assets/images/logo.png';
+import { Link, useRouteError } from 'react-router-dom';
 import { CustomButton } from '@/components/button';
 import { UI_ERRORS } from '@/constants/errors';
 import { STATUS_CODES } from '@/constants/statusCodes';
+import logoImg from '@/assets/images/logo.png';
 import * as S from '@/pages/error/styles';
-import { Link, useRouteError } from 'react-router-dom';
 
 const NotFoundPage = () => {
   const error = useRouteError();

--- a/src/pages/error/serverError/ServerErrorPage.jsx
+++ b/src/pages/error/serverError/ServerErrorPage.jsx
@@ -1,8 +1,8 @@
+import { useRouteError } from 'react-router-dom';
 import { CustomButton } from '@/components/button';
 import { UI_ERRORS } from '@/constants/errors';
 import { STATUS_CODES } from '@/constants/statusCodes';
 import * as S from '@/pages/error/styles';
-import { useRouteError } from 'react-router-dom';
 
 const ServerErrorPage = () => {
   const error = useRouteError();
@@ -18,14 +18,16 @@ const ServerErrorPage = () => {
         <h1>{status}</h1>
         <h2>{statusText}</h2>
         <p>{uiMessage}</p>
-        <CustomButton
-          variant="error"
-          isRound="true"
-          style={S.errorButtonStyle}
-          onButtonClick={() => window.location.reload()}
-        >
-          다시 시도
-        </CustomButton>
+        <div css={S.buttonWrapper}>
+          <CustomButton
+            variant="error"
+            isRound="true"
+            style={S.errorButtonStyle}
+            onButtonClick={() => window.location.reload()}
+          >
+            다시 시도
+          </CustomButton>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/error/styles/baseError.styles.js
+++ b/src/pages/error/styles/baseError.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css, keyframes } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const auroraMove = keyframes`
   0% {

--- a/src/pages/landing/LandingPage.jsx
+++ b/src/pages/landing/LandingPage.jsx
@@ -1,7 +1,7 @@
-import { CustomButton } from '@/components/button';
-import { motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
+import { motion } from 'motion/react';
 import { Link, useLoaderData } from 'react-router-dom';
+import { CustomButton } from '@/components/button';
 import * as S from './landingPage.styles';
 
 const stars = [

--- a/src/pages/landing/landingPage.styles.js
+++ b/src/pages/landing/landingPage.styles.js
@@ -1,6 +1,6 @@
-import starImg from '@/assets/images/star.png';
-import media from '@/styles/responsive';
 import { css, keyframes } from '@emotion/react';
+import media from '@/styles/responsive';
+import starImg from '@/assets/images/star.png';
 
 const auroraMove = keyframes`
   0% {

--- a/src/pages/list/ListPage.jsx
+++ b/src/pages/list/ListPage.jsx
@@ -1,17 +1,15 @@
+import { useEffect, useState } from 'react';
+import { useLoaderData } from 'react-router-dom';
 import { Carousel } from '@/components/carousel';
 import { Charge } from '@/components/charge';
 import { Chart } from '@/components/chart';
 import { ListModal } from '@/components/list';
-import { css } from '@emotion/react';
-import { useEffect, useState } from 'react';
-import { useLoaderData } from 'react-router-dom';
 import * as S from './listPage.styles';
 
 const ListPage = () => {
   const [modalType, setModalType] = useState(null); // 모달 타입 상태 관리
   const [credit, setCredit] = useState(0); // 크레딧 상태 관리
   const { idols, donations } = useLoaderData(); // 여기서 데이터 받음
-  console.log('여기', donations);
   const [selectedTab, setSelectedTab] = useState('females');
   const [selectedIndex, setSelectedIndex] = useState(null); // 후원의 인덱스를 받아옴
 

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -1,8 +1,8 @@
-import addIcon from '@/assets/icons/plus-icon.png';
-import { Avatar } from '@/components/avatar';
-import { ArrowButton, AvatarButton, CustomButton } from '@/components/button';
 import { useEffect, useState } from 'react';
 import { useLoaderData } from 'react-router-dom';
+import { Avatar } from '@/components/avatar';
+import { ArrowButton, AvatarButton, CustomButton } from '@/components/button';
+import addIcon from '@/assets/icons/plus-icon.png';
 import * as S from './myPage.styles';
 
 const MyPage = () => {

--- a/src/pages/my/myPage.styles.js
+++ b/src/pages/my/myPage.styles.js
@@ -1,5 +1,5 @@
-import media from '@/styles/responsive';
 import { css } from '@emotion/react';
+import media from '@/styles/responsive';
 
 export const myPageWrapper = css`
   margin: auto;

--- a/src/routes/router.jsx
+++ b/src/routes/router.jsx
@@ -1,10 +1,10 @@
+import { createBrowserRouter } from 'react-router-dom';
 import { fetchCharts, fetchDonations, fetchIdols } from '@/api';
+import { ApiErrorBoundary, GlobalErrorBoundary, RenderErrorBoundary } from '@/errorBoundary';
 import { THROWN_ERRORS } from '@/constants/errors';
 import { STATUS_CODES } from '@/constants/statusCodes';
-import { ApiErrorBoundary, GlobalErrorBoundary, RenderErrorBoundary } from '@/errorBoundary';
 import { safeRequest } from '@/utils/api';
 import { throwIfEmptyArray } from '@/utils/validate';
-import { createBrowserRouter } from 'react-router-dom';
 
 const router = createBrowserRouter([
   {
@@ -48,7 +48,7 @@ const router = createBrowserRouter([
             loader: async () => {
               const idols = await safeRequest(() => fetchIdols({ limit: 10, cursor: 0 }), 'idols');
               const donations = await safeRequest(
-                () => fetchDonations({ limit: 10, cursor: 0 }),
+                () => fetchDonations({ limit: 30, cursor: 0 }),
                 'donations',
               );
               const charts = await safeRequest(
@@ -77,7 +77,7 @@ const router = createBrowserRouter([
               </RenderErrorBoundary>
             ),
             loader: async () => {
-              const idols = await safeRequest(() => fetchIdols({ limit: 10, cursor: 0 }), 'idols');
+              const idols = await safeRequest(() => fetchIdols({ limit: 30, cursor: 0 }), 'idols');
               throwIfEmptyArray(idols);
               return idols;
             },

--- a/src/utils/alert/index.js
+++ b/src/utils/alert/index.js
@@ -1,0 +1,1 @@
+export { registerAlertTrigger, showAlert } from './alertController';

--- a/src/utils/api/axiosInstance.js
+++ b/src/utils/api/axiosInstance.js
@@ -1,5 +1,5 @@
-import { UI_ERRORS } from '@/constants/errors';
 import axios from 'axios';
+import { UI_ERRORS } from '@/constants/errors';
 
 /**
  * Axios 인스턴스


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #253 

## ✨ 요약
화면 전환 시 PedningUI가 보이고 새로운 화면이 보이는게 아니라 PendingUI가 보이고 스크롤로 내리면 새 화면이 보이는 문제를 해결했습니다. 그 외 여러가지 사항들을 데모 전 마지막으로 점검하고 수정했습니다. 


## 📌 주요 변경 사항
- pendingUI가 보이고 화면이 보이는게 아니라 pendingUI보이고 스크롤로 내리면 화면이 보이는 문제 해결했습니다. 
- 라우터에서 donation첫데이터 30개 보내도록 설정했어요.(근데 데이터 토탈 12개 있음) 
- creditLackModal border radius 지정했습니다. 
- 서버에러페이지 버튼 가운데 정렬로 수정했습니다.  
- credit이미지를 logo star로 변경했습니다. 
- import 지난 PR 기준에 맞게 수동으로 수정했습니다. 
- index파일 없는 부분 중 필요하다고 생각하는 일부는 생성했고 경로 맞게 수정했습니다. 

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [x] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [x] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

## ❓무슨 문제가 발생했나요 ?
- 서버에러 나는거 한번 더 체크해봤는데 500 서버에러 외에도 서버 관련 이슈가 있긴 한거 같아요. 
페이지 루트 못찾고 404에러 띄우고 있어요. 찾아보니 S3의 경우  /index.html로 리다이렉트 설정해야한다는데 이건 이따가 같이 얘기해봐요. 
- 리스트페이지쪽 fetchData따로 쓰지말고 있는거 쓰도록 수정 필요합니다. 

## 💬 논의 사항
- modals/commonModal/을 template/modal로 뺄까요?


## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 여러 파일에서 import 구문 정렬 및 경로 단순화로 코드 일관성을 개선하였습니다.
  - 일부 컴포넌트의 시각적 자산(이미지) 변경 및 스타일에 border-radius 추가 등 UI 요소가 소폭 변경되었습니다.
  - 로딩 상태에서 메인 콘텐츠 대신 로딩 UI만 표시되도록 렌더링 로직이 개선되었습니다.
  - 리스트 페이지에서 한 번에 불러오는 항목 수가 10개에서 30개로 증가하였습니다.

- **Chores**
  - 불필요한 콘솔 로그 및 중복 import가 제거되었습니다.
  - 공통 컴포넌트 및 유틸 함수의 import 경로가 간소화되어 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->