### PR TITLE
✨Feat: 마이페이지 모바일 사이즈에서 모든 아이돌 스크롤로 넘겨 볼수 있도록 구현

### DIFF
--- a/src/components/avatar/avatar.styles.js
+++ b/src/components/avatar/avatar.styles.js
@@ -12,7 +12,7 @@ export const imageSelected = css`
     z-index: 0;
     width: 100%;
     height: 100%;
-    border: 4px solid var(--black);
+    border: 4px solid var(--black-deep);
     border-radius: 50%;
     background: linear-gradient(
       271.36deg,
@@ -41,7 +41,7 @@ export const image = (size) => css`
   width: 100%;
   height: 100%;
   aspect-ratio: 1/1;
-  border: 4px solid var(--black);
+  border: 4px solid var(--black-deep);
   border-radius: 50%;
   box-shadow: 0 0 0 2px var(--orange);
   object-fit: cover;

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -50,7 +50,7 @@ const MyPage = () => {
 
   useEffect(() => {
     if (screenSize === 'mobile') {
-      setPageSize(6);
+      setPageSize(30);
     } else if (screenSize === 'tablet') {
       setPageSize(8);
     } else {
@@ -161,10 +161,12 @@ const MyPage = () => {
             />
           ) : null}
 
-          <section css={[S.idolList]}>
+          <section
+            css={[screenSize === 'mobile' ? [S.mobileAllIdols, S.scrollStyle] : null, S.idolList]}
+          >
             {currentIdols.map((idol) => {
               return (
-                <div key={idol.id} css={S.allProfileSize}>
+                <div key={idol.id} css={[S.allProfileSize]}>
                   <Avatar
                     imgUrl={idol.profilePicture}
                     onSelectToggle={() => toggleProfile(idol)}

--- a/src/pages/my/myPage.styles.js
+++ b/src/pages/my/myPage.styles.js
@@ -87,11 +87,11 @@ export const idolList = css`
   justify-content: center;
   width: 100%;
   ${media({
-    columnGap: ['1.7rem', '1.7rem', '2.4rem', '2.4rem', '2.4rem'],
+    columnGap: ['1rem', '1rem', '2.4rem', '2.4rem', '2.4rem'],
     rowGap: ['1rem', '1rem', '2.4rem', '2.4rem', '2.4rem'],
     gridTemplateColumns: [
       'repeat(3, minmax(9.8rem, 1fr))',
-      'repeat(3, minmax(9.8rem, 1fr))',
+      'repeat(3, minmax(2.8rem, 1fr))',
       'repeat(4, minmax(12.8rem, 1fr))',
       'repeat(8, minmax(9.8rem, 1fr))',
       'repeat(8, minmax(12.8rem, 1fr))',
@@ -125,4 +125,17 @@ export const prev = css`
 `;
 export const next = css`
   right: 0;
+`;
+
+export const mobileAllIdols = css`
+  /* height: 47rem; */
+  overflow: scroll hidden;
+  gap: 2.5rem;
+  grid-template-rows: repeat(2, 12rem); 
+  height: 36rem;
+  padding-top: 1rem;
+  padding-left: 2.4rem;
+  grid-auto-flow: column ;
+  grid-auto-columns: 9.8rem;
+  scroll-padding-left: 2.4rem;
 `;


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #258

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
마이페이지 모바일 사이즈에서 모든 아이돌 스크롤로 넘겨 볼수 있도록 구현
## 📌 주요 변경 사항
- 마이페이지 모바일 사이즈에서 모든 아이돌 스크롤로 넘겨 볼수 있도록 구현
- 모바일에서 색상이 너무 회색으로 나오는 문제로 인해 Avatar 색상값 수정
<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [x] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [x] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

- 구현 후

https://github.com/user-attachments/assets/eb6c7ec0-c03c-4d5d-bec9-270be5c7f0a0


## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 아바타 이미지와 선택된 상태의 테두리 색상이 더 진한 색상으로 변경되었습니다.
  - 아이돌 리스트의 그리드 간격 및 컬럼 최소 너비가 모바일 환경에서 조정되었습니다.
  - 모바일에서 아이돌 리스트가 가로 스크롤 가능한 2줄 그리드로 개선되었습니다.

- **신규 기능**
  - 모바일 화면에서 아이돌 리스트가 가로 스크롤 형태로 표시됩니다.

- **기능 개선**
  - 모바일에서 한 페이지에 보여지는 아이돌 개수가 6개에서 30개로 증가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->